### PR TITLE
Install rollbar dependency

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,7 @@ setup(
     author_email='dwelch2102@gmail.com',
     keywords='django distributed task queue worker scheduler cron redis disque ironmq sqs orm mongodb multiprocessing rollbar',
     packages=['django_q_rollbar'],
+    install_requires=['rollbar>=0.14.0'],
     url='https://django-q.readthedocs.org',
     license='MIT',
     description='A Rollbar support plugin for Django Q',

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='django-q-rollbar',
-    version='0.1.1',
+    version='0.1.2',
     author='Daniel Welch',
     author_email='dwelch2102@gmail.com',
     keywords='django distributed task queue worker scheduler cron redis disque ironmq sqs orm mongodb multiprocessing rollbar',


### PR DESCRIPTION
Add rollbar minimum dependency to install on extension install.

This prevents needing to install rollbar manually if it is not available yet.