### PR TITLE
Bump version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
 
 setup(
     name='django-q-rollbar',
-    version='0.1.3',
+    version='0.1.4',
     author='Daniel Welch',
     author_email='dwelch2102@gmail.com',
     keywords='django distributed task queue worker scheduler cron redis disque ironmq sqs orm mongodb multiprocessing rollbar',


### PR DESCRIPTION
I just noticed that version number 0.1.3 was already used for release last year.

Can you please publish this to PyPi? I'm using Pipenv and it has issues with setuptools extras, I can't get it to install this package directly from the repo :/ Thanks!

![obraz](https://user-images.githubusercontent.com/605104/136563507-a85bd07f-2cbe-48d4-953e-9c69f8550f8d.png)
